### PR TITLE
mongodb & storage api

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,8 @@
 [http]
 host = '0.0.0.0'
 port = 8080
+
+[mongodb]
+host = '127.0.0.1'
+port = 27017
+db = 'tozti'

--- a/config.toml
+++ b/config.toml
@@ -5,4 +5,3 @@ port = 8080
 [mongodb]
 host = '127.0.0.1'
 port = 27017
-db = 'tozti'

--- a/mongo_cfg.yml
+++ b/mongo_cfg.yml
@@ -1,0 +1,6 @@
+net:
+    port: 27017
+    bindIp: 127.0.0.1
+storage:
+    dbPath: ./data
+    engine: wiredTiger

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiohttp==2.3
 toml==0.9
 logbook==1.1
 pystache==0.5.4
+motor==1.2.0

--- a/tozti/store.py
+++ b/tozti/store.py
@@ -16,22 +16,71 @@
 # along with Tozti.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from aiohttp import web
+from json import JSONDecodeError
+from datetime import datetime, timezone
+from uuid import uuid4
+
+
+from aiohttp.web import json_response
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from tozti.utils import RouterDef, api_error
+from tozti import logger
+from tozti.utils import RouterDef, register_error, api_error
 
+
+register_error('ENTITY_NOT_FOUND', 'entity {eid} not found', 404)
+register_error('NOT_JSON', 'expected json data', 406)
+register_error('BAD_JSON', 'malformated json data', 400)
+register_error('INVALID_ENTITY', 'invalid entity content: {err}', 400)
+
+
+########
+# Routes
 
 router = RouterDef()
-entity = router.add_resource('/entity/{eid:[0-9a-f]{8,8}}')
+
+entity = router.add_resource('/entity')
+
+uuid_re = '-'.join('[0-9a-fA-F]{%d}' % i for i in (8, 4, 4, 4, 12))
+entity_single = router.add_resource('/entity/{eid:%s}' % uuid_re)
 
 
-@entity.get
+
+@entity.post
+async def entity_post(req):
+    """POST /api/store/entity
+
+    Returns newly created entity.
+    """
+
+    if req.content_type != 'application/json':
+        return api_error('NOT_JSON')
+    try:
+        data = await req.json()
+    except JSONDecodeError:
+        return api_error('BAD_JSON')
+    try:
+        eid = await req.app['tozti-store'].create_entity(data)
+    except ValueError as err:
+        return api_error('INVALID_ENTITY', err=err)
+    return json_response(await req.app['tozti-store'].get_entity(eid))
+
+@entity_single.get
 async def entity_get(req):
-    entity = await req.app['tozti-store'].get_entity(
-        int(req.match_info['eid'], 16))
-    return web.json_response(entity)
+    """GET /api/store/entity/{eid}
 
+    Returns matching entity if existing and readable.
+    """
+
+    eid = req.match_info['eid']
+    try:
+        return json_response(await req.app['tozti-store'].get_entity(eid))
+    except KeyError:
+        return api_error('ENTITY_NOT_FOUND', eid=eid)
+
+
+#########
+# Backend
 
 async def open_db(app):
     """Initialize storage backend at app startup."""
@@ -45,14 +94,31 @@ async def close_db(app):
 
 class EntityStore:
     def __init__(self, **kwargs):
-        db = kwargs.pop('db', 'tozti')
-        self._db_name = db
         self._client = AsyncIOMotorClient(**kwargs)
-        self.db = self._client[db]
-        
+        self._entities = self._client.tozti.entities
 
     async def get_entity(self, eid):
-        return await self.db.entities.find_one({'eid': eid})
+        logger.debug('querying DB for entity {}'.format(eid))
+        resp = await self._entities.find_one({'eid': eid})
+        if resp is None:
+            raise KeyError
+        del resp['_id']
+        return resp
 
     async def close(self):
         self._client.close()
+
+    async def create_entity(self, data):
+        logger.debug('incoming data: {}'.format(data))
+        if 'type' not in data:
+            raise ValueError('missing type property')
+
+        # complete the metadata
+        eid = str(uuid4())
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        data['creation'] = now.isoformat()
+        data['last-edit'] = now.isoformat()
+        data['eid'] = eid
+
+        await self._entities.insert_one(data)
+        return eid

--- a/tozti/store.py
+++ b/tozti/store.py
@@ -1,0 +1,58 @@
+# -*- coding:utf-8 -*-
+
+# This file is part of Tozti.
+
+# Tozti is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Tozti is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with Tozti.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from aiohttp import web
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from tozti.utils import RouterDef, api_error
+
+
+router = RouterDef()
+entity = router.add_resource('/entity/{eid:[0-9a-f]{8,8}}')
+
+
+@entity.get
+async def entity_get(req):
+    entity = await req.app['tozti-store'].get_entity(
+        int(req.match_info['eid'], 16))
+    return web.json_response(entity)
+
+
+async def open_db(app):
+    """Initialize storage backend at app startup."""
+    app['tozti-store'] = EntityStore(**app['tozti-config']['mongodb'])
+
+
+async def close_db(app):
+    """Close storage backend at app cleanup."""
+    await app['tozti-store'].close()
+
+
+class EntityStore:
+    def __init__(self, **kwargs):
+        db = kwargs.pop('db', 'tozti')
+        self._db_name = db
+        self._client = AsyncIOMotorClient(**kwargs)
+        self.db = self._client[db]
+        
+
+    async def get_entity(self, eid):
+        return await self.db.entities.find_one({'eid': eid})
+
+    async def close(self):
+        self._client.close()

--- a/tozti/store.py
+++ b/tozti/store.py
@@ -103,6 +103,8 @@ class EntityStore:
         if resp is None:
             raise KeyError
         del resp['_id']
+        resp['creation'] = resp['creation'].isoformat()
+        resp['last-edit'] = resp['last-edit'].isoformat()
         return resp
 
     async def close(self):
@@ -116,8 +118,8 @@ class EntityStore:
         # complete the metadata
         eid = str(uuid4())
         now = datetime.now(timezone.utc).replace(microsecond=0)
-        data['creation'] = now.isoformat()
-        data['last-edit'] = now.isoformat()
+        data['creation'] = now
+        data['last-edit'] = now
         data['eid'] = eid
 
         await self._entities.insert_one(data)

--- a/tozti/utils.py
+++ b/tozti/utils.py
@@ -16,6 +16,9 @@
 # along with Tozti.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from aiohttp.web import json_response
+
+
 class ResourceDef:
     """Definition of a resource.
 
@@ -133,3 +136,16 @@ class RouterDef:
 
     def __iter__(self):
         return iter(self._resources)
+
+
+API_ERRORS = {}
+
+def register_error(name, fmt, status):
+    if name in API_ERRORS:
+        raise ValueError('error %s already defined' % name)
+    API_ERRORS[name] = (len(API_ERRORS), fmt, status)
+
+def api_error(name, **vars):
+    code, fmt, status = API_ERRORS[name]
+    return json_response({'error': code, 'msg': fmt.format(**vars)},
+                         status=status)


### PR DESCRIPTION
So, here are some changes that add a mongodb backend and some basic storage api (will probably be renamed etc).

## What works

Config files are in `mongo_cfg.yml`, start mongodb (package `mongodb` on most distros) with `mongod -f mongo_cfg.yml` (you must create a `data` directory).

I refactored the registration mechanism for extensions to separate the logic from the extension discovery so that we can simply call `register` to add routes/js/whatever that comes from the core (eg `tozti/__main__.py#L148`). This will need some merging since there has been some changes (toposort of extensions) in the registration mechanism in `master`.

New section `mongodb` in the tozti config file: `port` and `host` (dunno if it works if we give a path to a unix socket file as host (and empty port) but it should, at some point we should check it works as it should be the right way to deploy it for real).

I added some helpers to report errors consistently in the API (`tozti/utils.py`).

Entity creation: `POST /api/store/entity` with a json payload containing an object with at least a `type` property. Properties `eid` (random [UUIDv4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random))), `creation-date` (current UTC date in iso8601) and `last-edit` (same date).

Entity retrieval: `GET /api/store/entity/{EID}` returns the json payload.

## What's next

### Backend

- [ ] factor out the "completion" of properties that should be added during creation so that it might be extended per entity type (generate eid, creation date, etc), TODO: or maybe not, types will probably not change that
- [ ] factor out the "rendering" of the raw mongodb document into the json object we return in the API (for now it's only removing `_id` but this should also generate dynamically what we called "backlinks" by doing some more queries on a per-type basis)

### Frontend (api)

Now how do we want the api to look like? I would go for something like json-api, i guess is somewhat a compromise between something fancy cool and something that has been somewhat field proven. Note that they use "resource" for what i called "entity", it's probably a better name, let's switch to that. The only changes i would like to make to json-api are the following:

- [relationship objects](http://jsonapi.org/format/#document-resource-object-relationships) contains at least one of: `self` (same as their `links.self`), `data` (no change) and `meta` (no change)
- [resource identifier objects](http://jsonapi.org/format/#document-resource-identifier-objects) are simply an url to some resource
- the [`included` key](http://jsonapi.org/format/#fetching-includes) of a (compound) api response is a json object (not an array) where keys are the canonical url of an included resource (the one in `relationships.self.data`)
- `PUT` instead of `PATCH` for [overwriting to-many relationships](http://jsonapi.org/format/#crud-updating-to-many-relationships)

And also the following added restrictions (compatible with the spec):

- don't use `links` key in resources (it is optional anyway)
- `relationships` containts at least:
  - `self`: to-one, the current resource, not writable
  - `creator`, to-one, the user that first created the resources, not writeable
  - `read`: to-many, list of groups/users allowed (only) to read
  - `write`: to-many, list of groups/users allowed (only) to read and write anything but access-control-lists
  - `own`: to-many, list of groups/users allowed to read and write anything
- `id` is an UUIDv4 formated as hex string with dashes (as in the spec of uuids)
- `meta` (top level key on resources) must contain `creation` (iso8601 date), `last-edition` (same) and is not writable
- only return 1 error (simpler and probably safer to avoid leaking infos), errors may only contain `code`, `title`, `detail` and `source`

URLs / endpoints (everything here prefixed by `https://HOST/api/store`):

- `/resource/{ID}`: canonical url to some resource
- `/resource/{ID}/{rel}`: url to a [relationship](http://jsonapi.org/format/#fetching-relationships)

### More unknown stuff

- authentication (let's do that after we have unauthenticated api somewhat working, so that we can implement users)
- types: my guess would be that `type` is an url to a json document, that json document contains:
  - `attributes` which is a [json-schema](https://spacetelescope.github.io/understanding-json-schema/index.html) that the `attributes` key of the resources of that type must validate
  - `relationships` which is an object where keys are names of some possible relationships, and values are json-objects containing:
    - `required`: bool (optional, defaults to true)
    - `target`: type or array of types which are allowed as targets (optional, defaults to any)
    - `arity`: either `"one"` or `"many"`, wether this is a to-one or a to-many relationship (optional, defaults to `"one"`)
    - `reverse-of`: a json object with key `type` and `relationship`, this specifies that the current relationship should contain every resource of the given type that has the current resource in the given relationship; if present, `reverse-of` should be the only given key
  - `access`: an object where keys are names of new access-control-lists (in addition to `read`, `write` and `own`) and values are json-objects containing an array of strings that are names of to-many relationships. This will allow groups in the list to call `POST /resources/{ID}/{rel}` to append something (eg post in a topic, add a subtag to a tag, add some user to a group, etc). We need to make sure we always allow people to undo their action (so keep in mongodb how added what to to-many relationships).
- encryption: maybe extend the type specification to include the fact that some attribute or relationship should be encrypted or maybe (alternatively or additionaly) mark some resources (on a per-resource basis) as completely (or just `attributes` and `relationships`) encrypted (i like this second option better)
- there should be an endpoint like `/upload` for uploading raw data (like multimedia), it should return an arbitrary permalink, maybe add a config file entry specifying what content-types we allow to upload, maybe volume-restriction per-user
- maybe extend the access-control specification in types to lock down the readability of some attributes of a resource. Example: restrict the preferences of some user to the `own` group of that user (ie himself)