### PR TITLE
Definition of core schemas.

### DIFF
--- a/tozti/core_schemas.py
+++ b/tozti/core_schemas.py
@@ -2,7 +2,7 @@ user_schema = {
     'attributes': {
         'name': { 'type': 'string' },
         'email': { 'type': 'string', 'format': 'email' },
-        'login': { 'type': 'string' },
+        'handle': { 'type': 'string' },
         'avatar': { 'type': 'string' }, # TODO(Lapin0t): upload id
 
         # TODO: config + notif
@@ -25,13 +25,15 @@ user_schema = {
 
 group_schema = {
     'attributes': {
-        'name': { 'type': 'string' }
+        'name': { 'type': 'string' },
+        'handle': { 'type': 'string' },
+        'avatar': { 'type': 'string' },
     },
 
     'relationships': {
         'members': {
             'reverse-of': {
-                'type': 'core/user',
+                'type': ['core/user', 'core/group'],
                 'path': 'groups'
             }
         },

--- a/tozti/core_schemas.py
+++ b/tozti/core_schemas.py
@@ -48,18 +48,6 @@ group_schema = {
     }
 }
 
-acl_schema = {
-    'type': 'object',
-    'patternProperties': {
-        '.*': {
-            'type': 'object'
-            'properties': {
-                'type': { 'type': 'string' },
-                'key': { 'type': 'string' },
-            }
-        }
-    }
-}
 
 folder_schema = {
     'attributes': {
@@ -76,51 +64,6 @@ folder_schema = {
                 'path': 'children'
             }
         },
-    }
-}
-
-# core/thread
-thread_schema = {
-    'attributes': {
-        'title': { 'type': 'string' },
-    },
-    'relationships': {
-        'posts': {
-            'arity': 'to-many',
-            'type': 'discussion/post'
-        }
-    }
-}
-
-# core/post
-post_schema = {
-    'attributes': {
-        'title': { 'type': 'string' },
-    },
-
-    'relationships': {
-        'thread': {
-            'reverse-of': {
-                'type': 'discussion/thread',
-                'path': 'posts'
-            }
-        },
-
-        'parent': {
-            'arity': 'to-one',
-            'type': 'discussion/post'
-        },
-
-        'responses': {
-            'reverse-of': {
-                'type': 'discussion/post',
-                'path': 'parent'
-            }
-        },
-
-        'attachments': {
-            'arity': 'to-many'
-        }
     }
 }
 

--- a/tozti/core_schemas.py
+++ b/tozti/core_schemas.py
@@ -2,14 +2,22 @@ user_schema = {
     'attributes': {
         'name': { 'type': 'string' },
         'email': { 'type': 'string', 'format': 'email' },
-        'login': { 'type': 'string' }
+        'login': { 'type': 'string' },
+        'avatar': { 'type': 'string' }, # TODO(Lapin0t): upload id
+
+        # TODO: config + notif
     },
+
     'relationships': {
         'groups': {
-            'reverse-of': {
-                'type': 'core/group',
-                'path': 'members'
-            }
+            'arity': 'to-many',
+            'type': 'core/group',
+        },
+
+        # folders the user has made accessible from its sidebar
+        'pinned': {
+            'arity': 'to-many',
+            'type': 'core/folder'
         }
     }
 }
@@ -19,13 +27,106 @@ group_schema = {
     'attributes': {
         'name': { 'type': 'string' }
     },
+
     'relationships': {
         'members': {
+            'reverse-of': {
+                'type': 'core/user',
+                'path': 'groups'
+            }
+        },
+
+        'groups': {
             'arity': 'to-many',
-            'type': 'core/user'
+            'type': 'core/group',
+        },
+
+        'pinned': {
+            'arity': 'to-many',
+            'type': 'core/folder'
+        },
+    }
+}
+
+acl_schema = {
+    'type': 'object',
+    'patternProperties': {
+        '.*': {
+            'type': 'object'
+            'properties': {
+                'type': { 'type': 'string' },
+                'key': { 'type': 'string' },
+            }
+        }
+    }
+}
+
+folder_schema = {
+    'attributes': {
+        'name': { 'type': 'string' }
+    },
+
+    'relationships': {
+        'children': {
+            'arity': 'to-many'
+        },
+        'parents': {
+            'reverse-of': {
+                'type': 'core/folder',
+                'path': 'children'
+            }
+        },
+    }
+}
+
+# core/thread
+thread_schema = {
+    'attributes': {
+        'title': { 'type': 'string' },
+    },
+    'relationships': {
+        'posts': {
+            'arity': 'to-many',
+            'type': 'discussion/post'
+        }
+    }
+}
+
+# core/post
+post_schema = {
+    'attributes': {
+        'title': { 'type': 'string' },
+    },
+
+    'relationships': {
+        'thread': {
+            'reverse-of': {
+                'type': 'discussion/thread',
+                'path': 'posts'
+            }
+        },
+
+        'parent': {
+            'arity': 'to-one',
+            'type': 'discussion/post'
+        },
+
+        'responses': {
+            'reverse-of': {
+                'type': 'discussion/post',
+                'path': 'parent'
+            }
+        },
+
+        'attachments': {
+            'arity': 'to-many'
         }
     }
 }
 
 
-SCHEMAS = {'user': user_schema, 'group': group_schema}
+SCHEMAS = {
+    'user': user_schema,
+    'group': group_schema,
+    'folder': folder_schema
+}


### PR DESCRIPTION
We define `core/user`, `core/group` and `core/folder`. One of the interesting points is that we want links to be oriented bottom-up so that walking the graph in practice is efficient.

### User

Attributes:

* `name`: the username, unicity not enforced
* `email`: simple
* `login`: login key, unicity enforced
* `avatar`: a string containing some kind of reference to a static file that has been uploaded (@liautaud you didn't want URLs but i don't recall why)

Relationships:

* `groups`: _to-many_ to `core/group` containing the list of groups a user is part of.
* `pinned`: _to-many_ to `core/folder` containing the list of folders a user wants to see at the root level

### Group

Attributes:

* `name`: display name, unicity not enforced

Relationships:

* `groups`: _to-many_ to `core/group` containing the list of super-groups the group is part of.
* `pinned`: _to-many_ to `core/folder` containing the list of root folders of the group (his _workspaces_).
* `members`: _reverse-of_ from `(["core/user", "core/group"], "groups")`

### Folder

Attributes:

* `name`: display name, unicity not enforced

Relationships:

* `children`: _to-many_ to any type listing the content of the "directory"
* `parents`: _reverse-of_ from `("core/folder", "children")`

### Question

* Is the name `core/folder` good? We may want to call it `core/tree` to re-use git nomenclature (it's really the same kind of object, apart from mutability). Other names i can think of are `core/tag` and `core/node`.
* Add `slug` and `avatar` attributes to `core/group`, `slug` being like `login` of `core/user`, ie the thing you can `@mention`. Maybe change `login` in `core/user` to `slug` to match it.