### PR TITLE
Fixed wrong path for static images

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -30,7 +30,7 @@ module.exports = {
   plugins: [
     new ExtractPlugin('css/[name].css'),
     new CopyWebpackPlugin([
-      { from: 'assets/img/', to: 'dist/img/', }
+      { from: 'assets/img/', to: 'img/', }
     ])
   ],
 


### PR DESCRIPTION
So, it's a bit silly to do a pull request for this change only,
but our recent PR for favicon support was flawed, making the build system move static images to the wrong subfolder.
This should be fixed, and never to be touched again.