### PR TITLE
Fixed tozti.store.update, added settings view

### DIFF
--- a/client/components/views/Settings.vue
+++ b/client/components/views/Settings.vue
@@ -1,0 +1,53 @@
+<template>
+  <section class="section content">
+    <h1>Paramètres</h1>
+    <div class="tabs">
+      <ul>
+        <li class="is-active"><a>Profil</span></a></li>
+        <li><a>Confidentialité</a></li>
+      </ul>
+    </div>
+    <form @submit.prevent="updateProfile">
+      <b-field label-for="name" label="Nom">
+        <b-input
+          v-model="user.name"
+          ref="name"
+          required>
+        </b-input>
+      </b-field>
+      <input
+        class="button is-primary"
+        type="submit"
+        value="Mettre à jour">
+    </form>
+  </section>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        user: { name: tozti.me.attributes.name }
+      }
+    },
+
+    methods: {
+      updateProfile() {
+        tozti.store
+          .update({ id: tozti.me.id, attributes: this.user })
+          .then(() => {
+            this.$toast.open({
+              message: 'Votre profil a été mis à jour !',
+              type: 'is-success'
+            })
+          })
+          .catch(() => {
+            this.$toast.open({
+              message: 'Une erreur est survenue lors de la mise à jour.',
+              type: 'is-danger'
+            })
+          })
+      }
+    }
+  }
+</script>

--- a/client/main.js
+++ b/client/main.js
@@ -63,6 +63,7 @@ const tozti = window.tozti = {
   globalMenuItems:
     [ { name: 'Mes groupes', route: '/g/', props: { icon: 'nc-multiple-11' } }
     , { name: 'Mes espaces', route: '/w/', props: { icon: 'nc-grid-45' } }
+    , { name: 'Paramètres', route: '/settings', props: { icon: 'nc-settings-gear-63' } }
   ],
 
   workspaceMenuItems: [

--- a/client/routes.js
+++ b/client/routes.js
@@ -8,6 +8,7 @@ import TaxonomyView from './components/views/Taxonomy.vue'
 import Workspaces from './components/views/Workspaces.vue'
 import Groups from './components/views/Groups.vue'
 import GroupView from './components/views/Group.vue'
+import SettingsView from './components/views/Settings.vue'
 
 
 const singleRoutes =
@@ -31,6 +32,8 @@ const enclosedRoutes =
     , component: GroupView
     , props: route => ({ id: route.params.id }) 
     }
+
+  , { path: 'settings', component: SettingsView }
 
   , { path: 'w/', component: Workspaces }
   , { path: 'w/:id',  name: 'workspace', component: SummaryView }

--- a/client/store.js
+++ b/client/store.js
@@ -62,7 +62,7 @@ const store = {
    */
   update(resource) {
     return api
-      .patch(tozti.api.resourceURL(resource.id), resource)
+      .patch(tozti.api.resourceURL(resource.id), { data: resource })
       .then(({ data }) => {
         return store.save(data)
       })


### PR DESCRIPTION
This PR fixes an error in the `update` method of the client store.
It now works properly, and can be used as seen in `Settings.vue`:

```js
tozti.store.update({ id: tozti.me.id, attributes: this.user })
```
For the sake of it, I added a Settings page where a user can update its name, to demonstrate both the `update` method and the reactivity working.