### PR TITLE
main content has now a 100% height. 

### DIFF
--- a/assets/sass/components/_layout.scss
+++ b/assets/sass/components/_layout.scss
@@ -11,11 +11,12 @@ $avatar-size: 43px;
 
 html {
 	background: #fcfcfc;
-  min-height: 100%;
+    height: 100%;
 }
 
 body {
-  height: 100vh;
+    height: 100%;
+	padding-top: $header-height + $separator-size;
 }
 
 .main-header {
@@ -190,9 +191,9 @@ span.placeholder {
 }
 
 .main-content {
+    height: 100%;
 
 	padding: $content-padding;
-	margin-top: $header-height + $separator-size;
 	margin-left: $sidebar-width + $separator-size;
 
 	font-size: .96rem;

--- a/assets/sass/components/_layout.scss
+++ b/assets/sass/components/_layout.scss
@@ -11,11 +11,9 @@ $avatar-size: 43px;
 
 html {
 	background: #fcfcfc;
-    height: 100%;
 }
 
 body {
-    height: 100%;
 	padding-top: $header-height + $separator-size;
 }
 
@@ -191,8 +189,6 @@ span.placeholder {
 }
 
 .main-content {
-    height: 100%;
-
 	padding: $content-padding;
 	margin-left: $sidebar-width + $separator-size;
 
@@ -220,6 +216,14 @@ span.placeholder {
       color: #ccc;
     }
   }
+}
+
+.fixed-content {
+	position: fixed;
+	left: $sidebar-width + $separator-size;
+	top: $header-height + $separator-size;
+	right: 0;
+	bottom: 0;
 }
 
 .fixed-width {

--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <!-- height 100% to ensure that the space an extension can
+      take is 100% -->
+  <div style="height:100%">
     <b-loading :active="!ready"></b-loading>
     <router-view v-if="ready"></router-view>
   </div>

--- a/client/components/Tozti.vue
+++ b/client/components/Tozti.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <!-- height 100% to ensure that the space an extension can
+      take is 100% -->
+  <div style="height:100%">
     <header class="main-header">
 
       <section class="branding">


### PR DESCRIPTION
The goal of this PR is to fix an issue present when trying to have an "extension" take 100% of the height.
The multiple "height: 100%" are here to ensure that the main design will allow using some "height: 100%" inside of some flexbox.