### PR TITLE
Storage API documentation

### DIFF
--- a/docs/dev/extensions/index.rst
+++ b/docs/dev/extensions/index.rst
@@ -6,3 +6,4 @@ Developing Extensions
 
    getting-started
    jsapi
+   storage

--- a/docs/dev/extensions/jsapi.rst
+++ b/docs/dev/extensions/jsapi.rst
@@ -2,7 +2,6 @@
 Using Tozti's JS api
 ********************
 
-
 Defining routes on the client side
 ==================================
 
@@ -18,7 +17,9 @@ to define new routes.
 
 Imagine you want to define a new 'page' displaying a component called ``Calendar`` that 
 can be accessed on ``<tozti>/mycalendar``. Then, you must add the following lines in your
-``index.js``::
+``index.js``:
+
+.. code-block:: javascript
 
     tozti.addRoutes([
       { path: '/mycalendar', component: Calendar }
@@ -37,17 +38,21 @@ items that are attached to tozti as a whole, not to a workspace.
 The corresponding method allowing to do that is called ``tozti.addMenuItem``. 
 Here are following examples of usage:
 
-- Adding an item with the text 'item' associated with the route `target/`::
+- Adding an item with the text 'item' associated with the route `target/`:
+
+.. code-block:: javascript
 
     tozti.addMenuItem('item', 'target/')
 
-- Adding an item with the text 'item' associated with the route `target/` 
-  and the icon 'nc-home-52'::
 
-    tozti.addMenuItem('item', 'target/', 
-                      props = {'icon': 'nc-home-52'}
-                      )
+- It is possible to specify which icon to use with the item inside the sidebar.
+  For this, you simply have to give additional properties as a third parameter.
+  The `icon` field should be a CSS class from the Nucleo App Free Icon set.
+  (This might & most surely will change later on).
+  
+.. code-block:: javascript
 
+    tozti.addMenuItem('item', 'target/', {'icon': 'nc-home-52'})
 
 
 .. _getting-started`_: [TODO put link]

--- a/docs/dev/extensions/storage.rst
+++ b/docs/dev/extensions/storage.rst
@@ -1,0 +1,280 @@
+*****************************
+Comunicating with the storage
+*****************************
+
+More often than not, the purpose of an extension is to define new types of resources,
+and provide new interactions with them from the tozti interface.
+For this purpose, tozti provides an easy way to define new types on the server-side,
+and a generic client-side API to query the store from the frontend.
+
+
+
+Defining new types of resources
+===============================
+
+For validation purposes, when you want to create a new type of resource in the store,
+you need to specify how such a resource is structured.
+This is done via **schemas**, similar to the JSONSchema specification.
+
+New type schemas can be defined from an extension by providing a new entry called `types`
+in the `MANIFEST` of the extension.
+This entry should be a dictionary, whose keys are the names of the new types, and values are
+valid schemas.
+
+Let's show how this works with a simple example, with our dummy extension.
+We would like to define a new resource type called `entity`, with attributes `name` and `age`.
+For the sake of it, let it also have a `to-many` relationship named `friends`.
+
+Therefore, our `MANIFEST` (defined in `server.py`) should look like::
+
+  MANIFEST = {
+    'types': {
+
+      'entity': {
+
+        'attributes': {
+          'name': { type: 'string' },
+          'age': { type: 'number' },
+        },
+
+        'relationships': {
+          'friends': {
+            'arity': 'to-many',
+            'type': 'dummy-extension/entity',
+          }
+        }
+
+      }
+
+    }
+  }
+
+Note that in the rest of this documentation, extension-defined type names will be prefixed
+by the name of the folder containing the extensions.
+Assuming our extension lives in a folder called `dummy-extension` in the `extensions` folder of
+our main tozti instance, the newly defined type will now be referred as `dummy-extensions/entity`.
+This also applies to the core `types`. For example, we provide by default types `core/user`, and `core/group`.
+That is why in the relationship `friends` of the type we just defined, we refer to `dummy-extensions/entity`.
+
+Further information on type schemas and how the storage uses them can be found in the documentation specific to the storage. (TODO: add link).
+
+
+Accessing the store from the JS API
+===================================
+
+
+Resources
+^^^^^^^^^
+
+Now that we registered a new type for resources in the store, we would like to have the ability to interact with such resources. tozti provides a generic API for this end, under the `tozti.store` namespace.
+
+
+Getting a resource
+------------------
+
+When you have the *uuid* of a resource, you can get its data from the store by using the `get` method:
+
+.. code-block:: javascript
+   tozti.store.get(uuid)
+
+This method returns a javascript **promise**, that resolves to the resource object, or rejects to the HTTP response object (allowing you to handle errors with a lot of flexibility).
+
+For exemple, assuming the variable `uuid` contains the uuid of a resource of type `dummy-extension/entity`,
+we can print the name of said entity by doing:
+
+.. code-block:: javascript
+   tozti.store
+     .get(uuid)
+     .then(resource => {
+       console.log(resource.attributes.name)
+     })
+     .catch(response => {
+       console.error('An error occured while fetching the resource.')
+     })
+
+
+Creating a new resource
+-----------------------
+
+To populate the store from the client-side, you have the ability to create new resources and send them
+to the server store. First define a new resource object:
+
+.. code-block:: javascript
+
+   let resource = {
+     type: 'dummy-extension/entity',
+     attributes: {
+       name: 'Some Entity',
+       age: 15,
+     }
+   }
+
+The only required field is the `type` field, for the storage to know what you are trying to create.
+Note that the associated `type` schema may itself require fields.
+
+Then, you can create the resource and send it to the store with the `create` method:
+
+
+.. code-block:: javascript
+
+   tozti.store.create(resource)
+
+
+This method also returns a javascript **promise**, that resolves to the full store resource object, or rejects to the HTTP response object.
+The resolved resource is a fully defined store resource, so it contains a `meta` field with meta informations, and `attributes` and `relationships` objects in accordance with the resource type.
+It also has an `id` field, which contains the uuid of the resource inside the store.
+
+.. code-block:: javascript
+
+   tozti.store
+     .create(resource)
+     .then(res => {
+       console.log('The resource was created.')
+       console.log(res.id)
+     })
+     .catch(response => {
+       console.error('An error occured while creating the resource.')
+     })
+
+
+Updating a resource
+-------------------
+
+Another usual operation is updating an existing resource.
+This is done via the `update` method.
+
+First, you need to define a resource object containing only the items that you want to see updated,
+and at the very least an `id`.
+
+.. code-block:: javascript
+
+   let changes = {
+     id: 'some-resource-id',
+     attributes: {
+       name: 'A new name for the entity',
+     }
+   }
+
+Then, using the `update` method tries to apply the changes:
+
+.. code-block:: javascript
+
+   tozti.store.update(changes)
+
+
+Again, this method returns a javascript **promise**, that resolves to the full store resource object, with the applied changes.
+
+.. code-block:: javascript
+
+   tozti.store
+     .update(changes)
+     .then(resource => {
+       console.log(resource.attributes.name)
+       // expected output: A new name for the entity
+     })
+     .catch(response => {
+       console.error('An error occured while updating the resource.')
+     })
+
+
+Deleting a resource
+-------------------
+
+Finaly, to delete a resource from the store, one can use the `delete` method.
+This method takes a resource object as a parameter, whose only needed field is `id`.
+(The fact that it takes a resource object is for convenience only).
+
+Assuming, `uuid` contains some entity id, and `resource` contains a complete resource object coming from the store,
+it can be used like this:
+
+.. code-block:: javascript
+
+   tozti.store.delete({ id: uuid })
+   tozti.store.delete(resource)
+
+As expected, this method also returns a **promise**, which resolves to an empty object when the deletion was successful, or to the HTTP response in the eventuality of an error.
+
+
+
+Relationships
+^^^^^^^^^^^^^
+
+If some resource has a relationship, then in the resource object returned from the store, the associated relationship field only contains a *linkage*, or an array of *linkages*.
+
+(Recall that a *linkage* is simply an object referring to a resource, containing fields `type` and `id`, plus additional data)
+
+tozti provides helper functions for fetch the entire data of relationships, or updating them, in the `tozti.store.rels` namespace.
+
+
+Getting the resources of a relationship
+---------------------------------------
+
+To get the entirety of the resources pointed by a relationship, use the `rels.fetch` method.
+It takes as a parameter a relationship object coming from some resource object returned by the store,
+and returns a Promise.
+
+This promise either resolves to a single resource object when the relationship is `to-one`, or to an array of resource objects when the relationship is `to-many`. 
+This promise is rejected if any of the resources contained in the relationship cannot be accessed from the server.
+
+For this reason, and for a better UX experience, it is preferred to not use `fetch` but instead defer the responsability of loading contained resources to individual components, that can display errors more intuitively. (See: part on using the store from vue, to be added)
+
+
+Assume that we have a resource `resource` of type `dummy-extension/entity`, then we can get all resources contained in the `friends` relationship by doing:
+
+.. code-block:: javascript
+
+   tozti.store.rels
+     .fetch(resource.relationships.friends)
+     .then(friends => {
+       // log the name of every friend in the relationship
+       friends.forEach(friend => {
+         console.log(friend.attributes.name)
+       })
+     })
+     .catch(response => {
+       console.error('An error occured while fetching some entities of the relationship')
+     })
+
+
+Appending resources to a `to-many` relationship
+-----------------------------------------------
+
+`rels.add` allows you to add some resource to a relationship. It takes a relationship object and a *linkage* as parameters, and returns a promise resolving to the new relationship object.
+Note that the original relationship object is actually mutated to correspond to the new relationship data.
+The linkage provided only requires an `id` field.
+
+Assuming we have two resources `pomme` and `poire` of type `dummy-extensions`,
+adding `poire` to the relationship `friends` of resource `pomme` is done like this:
+
+.. code-block:: javascript
+
+   tozti.store.rels
+     .add(pomme.relationships.friends, { id: poire.id })
+
+If the linkage already exists inside the relationship, it won't be added twice but the promise will still resolve correctly to the relationship object.
+
+
+Removing resources from a `to-many` relationship
+------------------------------------------------
+
+`rels.delete` does the exact opposite of `rels.add`: it allows you to remove some resource from a relationship.
+It takes a relationship object and the *linkage* to be removed, and returns a promise resolving to the new relationship object.
+
+Again, the original relationship object is actually mutated to correspond to the new relationship data.
+The linkage provided only requires an `id` field.
+
+Using the same exemple as before, we now want to remove `poire` from the relationship `friends` of resource `pomme`:
+
+.. code-block:: javascript
+
+   tozti.store.rels
+     .delete(pomme.relationships.friends, { id: poire.id })
+
+If the linkage does not exist inside the relationship, this method will have no effect on the relationship, but the promise will still resolve correctly to the relationship object.
+
+
+Updating a relationship
+-----------------------
+
+Unimplemented yet.
+This will be added soon.

--- a/docs/dev/extensions/storage.rst
+++ b/docs/dev/extensions/storage.rst
@@ -1,6 +1,6 @@
-*****************************
-Comunicating with the storage
-*****************************
+******************************
+Communicating with the storage
+******************************
 
 More often than not, the purpose of an extension is to define new types of resources,
 and provide new interactions with them from the tozti interface.
@@ -16,16 +16,16 @@ For validation purposes, when you want to create a new type of resource in the s
 you need to specify how such a resource is structured.
 This is done via **schemas**, similar to the JSONSchema specification.
 
-New type schemas can be defined from an extension by providing a new entry called `types`
-in the `MANIFEST` of the extension.
+New type schemas can be defined from an extension by providing a new entry called ``types``
+in the ``MANIFEST`` of the extension.
 This entry should be a dictionary, whose keys are the names of the new types, and values are
 valid schemas.
 
 Let's show how this works with a simple example, with our dummy extension.
-We would like to define a new resource type called `entity`, with attributes `name` and `age`.
-For the sake of it, let it also have a `to-many` relationship named `friends`.
+We would like to define a new resource type called ``entity``, with attributes ``name`` and ``age``.
+For the sake of it, let it also have a ``to-many`` relationship named ``friends``.
 
-Therefore, our `MANIFEST` (defined in `server.py`) should look like::
+Therefore, our ``MANIFEST`` (defined in ``server.py``) should look like::
 
   MANIFEST = {
     'types': {
@@ -33,8 +33,8 @@ Therefore, our `MANIFEST` (defined in `server.py`) should look like::
       'entity': {
 
         'attributes': {
-          'name': { type: 'string' },
-          'age': { type: 'number' },
+          'name': { 'type': 'string' },
+          'age': { 'type': 'integer' },
         },
 
         'relationships': {
@@ -51,10 +51,10 @@ Therefore, our `MANIFEST` (defined in `server.py`) should look like::
 
 Note that in the rest of this documentation, extension-defined type names will be prefixed
 by the name of the folder containing the extensions.
-Assuming our extension lives in a folder called `dummy-extension` in the `extensions` folder of
-our main tozti instance, the newly defined type will now be referred as `dummy-extensions/entity`.
-This also applies to the core `types`. For example, we provide by default types `core/user`, and `core/group`.
-That is why in the relationship `friends` of the type we just defined, we refer to `dummy-extensions/entity`.
+Assuming our extension lives in a folder called ``dummy-extension`` in the ``extensions`` folder of
+our main tozti instance, the newly defined type will now be referred as ``dummy-extensions/entity``.
+This also applies to the core ``types``. For example, we provide by default types ``core/user``, and ``core/group``.
+That is why in the relationship ``friends`` of the type we just defined, we refer to ``dummy-extensions/entity``.
 
 Further information on type schemas and how the storage uses them can be found in the documentation specific to the storage. (TODO: add link).
 
@@ -66,23 +66,25 @@ Accessing the store from the JS API
 Resources
 ^^^^^^^^^
 
-Now that we registered a new type for resources in the store, we would like to have the ability to interact with such resources. tozti provides a generic API for this end, under the `tozti.store` namespace.
+Now that we registered a new type for resources in the store, we would like to have the ability to interact with such resources. tozti provides a generic API for this end, under the ``tozti.store`` namespace.
 
 
 Getting a resource
 ------------------
 
-When you have the *uuid* of a resource, you can get its data from the store by using the `get` method:
+When you have the *uuid* of a resource, you can get its data from the store by using the ``get`` method:
 
 .. code-block:: javascript
+
    tozti.store.get(uuid)
 
 This method returns a javascript **promise**, that resolves to the resource object, or rejects to the HTTP response object (allowing you to handle errors with a lot of flexibility).
 
-For exemple, assuming the variable `uuid` contains the uuid of a resource of type `dummy-extension/entity`,
+For exemple, assuming the variable ``uuid`` contains the uuid of a resource of type ``dummy-extension/entity``,
 we can print the name of said entity by doing:
 
 .. code-block:: javascript
+
    tozti.store
      .get(uuid)
      .then(resource => {
@@ -109,10 +111,10 @@ to the server store. First define a new resource object:
      }
    }
 
-The only required field is the `type` field, for the storage to know what you are trying to create.
-Note that the associated `type` schema may itself require fields.
+The only required field is the ``type`` field, for the storage to know what you are trying to create.
+Note that the associated ``type`` schema may itself require fields.
 
-Then, you can create the resource and send it to the store with the `create` method:
+Then, you can create the resource and send it to the store with the ``create`` method:
 
 
 .. code-block:: javascript
@@ -121,8 +123,8 @@ Then, you can create the resource and send it to the store with the `create` met
 
 
 This method also returns a javascript **promise**, that resolves to the full store resource object, or rejects to the HTTP response object.
-The resolved resource is a fully defined store resource, so it contains a `meta` field with meta informations, and `attributes` and `relationships` objects in accordance with the resource type.
-It also has an `id` field, which contains the uuid of the resource inside the store.
+The resolved resource is a fully defined store resource, so it contains a ``meta`` field with meta informations, and ``attributes`` and ``relationships`` objects in accordance with the resource type.
+It also has an ``id`` field, which contains the uuid of the resource inside the store.
 
 .. code-block:: javascript
 
@@ -141,10 +143,10 @@ Updating a resource
 -------------------
 
 Another usual operation is updating an existing resource.
-This is done via the `update` method.
+This is done via the ``update`` method.
 
 First, you need to define a resource object containing only the items that you want to see updated,
-and at the very least an `id`.
+and at the very least an ``id``.
 
 .. code-block:: javascript
 
@@ -155,7 +157,7 @@ and at the very least an `id`.
      }
    }
 
-Then, using the `update` method tries to apply the changes:
+Then, using the ``update`` method tries to apply the changes:
 
 .. code-block:: javascript
 
@@ -180,11 +182,11 @@ Again, this method returns a javascript **promise**, that resolves to the full s
 Deleting a resource
 -------------------
 
-Finaly, to delete a resource from the store, one can use the `delete` method.
-This method takes a resource object as a parameter, whose only needed field is `id`.
+Finaly, to delete a resource from the store, one can use the ``delete`` method.
+This method takes a resource object as a parameter, whose only needed field is ``id``.
 (The fact that it takes a resource object is for convenience only).
 
-Assuming, `uuid` contains some entity id, and `resource` contains a complete resource object coming from the store,
+Assuming, ``uuid`` contains some entity id, and ``resource`` contains a complete resource object coming from the store,
 it can be used like this:
 
 .. code-block:: javascript
@@ -201,25 +203,25 @@ Relationships
 
 If some resource has a relationship, then in the resource object returned from the store, the associated relationship field only contains a *linkage*, or an array of *linkages*.
 
-(Recall that a *linkage* is simply an object referring to a resource, containing fields `type` and `id`, plus additional data)
+(Recall that a *linkage* is simply an object referring to a resource, containing fields ``type`` and ``id``, plus additional data)
 
-tozti provides helper functions for fetch the entire data of relationships, or updating them, in the `tozti.store.rels` namespace.
+tozti provides helper functions for fetch the entire data of relationships, or updating them, in the ``tozti.store.rels`` namespace.
 
 
 Getting the resources of a relationship
 ---------------------------------------
 
-To get the entirety of the resources pointed by a relationship, use the `rels.fetch` method.
+To get the entirety of the resources pointed by a relationship, use the ``rels.fetch`` method.
 It takes as a parameter a relationship object coming from some resource object returned by the store,
 and returns a Promise.
 
-This promise either resolves to a single resource object when the relationship is `to-one`, or to an array of resource objects when the relationship is `to-many`. 
+This promise either resolves to a single resource object when the relationship is ``to-one``, or to an array of resource objects when the relationship is ``to-many``. 
 This promise is rejected if any of the resources contained in the relationship cannot be accessed from the server.
 
-For this reason, and for a better UX experience, it is preferred to not use `fetch` but instead defer the responsability of loading contained resources to individual components, that can display errors more intuitively. (See: part on using the store from vue, to be added)
+For this reason, and for a better UX experience, it is preferred to not use ``fetch`` but instead defer the responsability of loading contained resources to individual components, that can display errors more intuitively. (See: part on using the store from vue, to be added)
 
 
-Assume that we have a resource `resource` of type `dummy-extension/entity`, then we can get all resources contained in the `friends` relationship by doing:
+Assume that we have a resource ``resource`` of type ``dummy-extension/entity``, then we can get all resources contained in the ``friends`` relationship by doing:
 
 .. code-block:: javascript
 
@@ -239,12 +241,12 @@ Assume that we have a resource `resource` of type `dummy-extension/entity`, then
 Appending resources to a `to-many` relationship
 -----------------------------------------------
 
-`rels.add` allows you to add some resource to a relationship. It takes a relationship object and a *linkage* as parameters, and returns a promise resolving to the new relationship object.
+``rels.add`` allows you to add some resource to a relationship. It takes a relationship object and a *linkage* as parameters, and returns a promise resolving to the new relationship object.
 Note that the original relationship object is actually mutated to correspond to the new relationship data.
-The linkage provided only requires an `id` field.
+The linkage provided only requires an ``id`` field.
 
-Assuming we have two resources `pomme` and `poire` of type `dummy-extensions`,
-adding `poire` to the relationship `friends` of resource `pomme` is done like this:
+Assuming we have two resources ``pomme`` and ``poire`` of type ``dummy-extensions``,
+adding ``poire`` to the relationship ``friends`` of resource ``pomme`` is done like this:
 
 .. code-block:: javascript
 
@@ -257,7 +259,7 @@ If the linkage already exists inside the relationship, it won't be added twice b
 Removing resources from a `to-many` relationship
 ------------------------------------------------
 
-`rels.delete` does the exact opposite of `rels.add`: it allows you to remove some resource from a relationship.
+``rels.delete`` does the exact opposite of ``rels.add``: it allows you to remove some resource from a relationship.
 It takes a relationship object and the *linkage* to be removed, and returns a promise resolving to the new relationship object.
 
 Again, the original relationship object is actually mutated to correspond to the new relationship data.


### PR DESCRIPTION
This PR adds documentation for the JS store API, i.e:
- defining new resource types from an extension;
- creating, updating, getting and deleting resources from the store;
- getting data, appending and removing resources from relationships

Unfortunately the API will change soon because of the current undergoing storage refactor.
But for now it will do just fine.

We do need to add a part on general principles of using this API inside Vue components.