### PR TITLE
Documentation for Vue store usage and reusable resource mixin

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -5,6 +5,7 @@ import promiseFinally from 'promise.prototype.finally'
 
 promiseFinally.shim()
 
+export * from './mixins'
 import { addRoutes, getRoutes } from './routes'
 import store from './store'
 import api from './api'


### PR DESCRIPTION
This PR extends the docuentation on the subject of fetching and syncing data from the store inside a Vue component.
I also exported the resourceMixin used in corejs to make it reusable from extensions via:

```js
import { resourceMixin } from 'tozti'
```
this should be the preferred way of loading a single resource from a component, as it will allow me to improve loading behavior on every component using it, soon as I get a better understanding of how reactivity and component reuse is handled.