### PR TITLE
Extension names

### DIFF
--- a/docs/dev/arch.rst
+++ b/docs/dev/arch.rst
@@ -2,7 +2,6 @@
 Architecture
 ************
 
-
 Tozti serves 3 main HTTP namespaces:
 
 - ``/static``: usual static files (javascript, css, images, etc)
@@ -17,21 +16,20 @@ The tozti core is really lightweight but it has the ability to load extensions.
 During the startup, the server will search for extensions in the ``extensions``
 subfolder of the tozti repository root.
 
+
 Directory structure and ``server.py``
 -------------------------------------
 
-An extension is a folder (whose name will determine the prefix under which the
-extension's files are served) containing at least a ``server.py`` file (or
-``server/__init__.py``). This file must contain a global variable ``MANIFEST``
-that is a dictionary containing the following keys (any one being optional):
 
 The tozti core is really lightweight but it has the ability to load extensions.
 For now, you only need to know that extension is a folder providing a python
-file (`server.py`), describing how the extension works on the server (its
-routes, which files must be included from the client...).
-An extension can be installed by pasting its folder inside tozti's
-`extensions/` folder. During startup, the server will go through every
-subfolders of `extensions/` and try to load them as an extension.
+file (`server.py` or ``server/__init__.py``), describing how the extension
+works on the server (its routes, which files must be included from the client).
+This file must contain a global variable ``MANIFEST`` that is a dictionary
+containing the following keys (any one being optional):
+
+``name``
+   The name of the extension, in lower-case and with dashes instead of spaces.
 
 ``includes``
    A list of css or js files that must be included in the main ``index.html``.
@@ -46,6 +44,7 @@ subfolders of `extensions/` and try to load them as an extension.
 
 The extension can contain a ``dist`` folder. The content of this folder will
 be served at the URL ``/static/<extension-name>``.
+
 
 Vuejs initialization
 --------------------

--- a/docs/dev/extensions/getting-started.rst
+++ b/docs/dev/extensions/getting-started.rst
@@ -15,7 +15,9 @@ proceed to create a folder ``extension-name``.  The only requirement for
 ``server.py`` declaring a dictionnary ``MANIFEST``.  Thus a minimal definition
 would be like so::
 
-    MANIFEST = {}
+    MANIFEST = {
+      'name': 'extension-name',
+    }
 
 Well done, you've just created your first extension!
 
@@ -70,6 +72,7 @@ just defined. This is where ``MANIFEST`` comes into use: We simply add the
 router in the ``MANIFEST`` dict under the key ``router``::
 
     MANIFEST = {
+        'name': 'extension-name',
         'router': router,
     }
 
@@ -134,6 +137,9 @@ Going further with ``MANIFEST``
 ===============================
 
 Here are a complete list of keys that ``MANIFEST`` can possess:
+
+``name``
+   The name of the extension, in lower-case and with dashes instead of spaces.
 
 ``router``
    This is used to declare new API endpoints. It should be an instance of

--- a/tests/extensions/rel01/server.py
+++ b/tests/extensions/rel01/server.py
@@ -16,4 +16,4 @@ bar_schema = {
         'relationships': {
             }
         }
-MANIFEST = {"types": {"foo": foo_schema, "bar": bar_schema}}
+MANIFEST = {"name": "rel01", "types": {"foo": foo_schema, "bar": bar_schema}}

--- a/tests/extensions/rel02/server.py
+++ b/tests/extensions/rel02/server.py
@@ -16,4 +16,4 @@ bar_schema = {
         'relationships': {
             }
         }
-MANIFEST = {"types": {"foo": foo_schema, "bar": bar_schema}}
+MANIFEST = {"name": "rel02", "types": {"foo": foo_schema, "bar": bar_schema}}

--- a/tests/extensions/routing01/server.py
+++ b/tests/extensions/routing01/server.py
@@ -13,5 +13,6 @@ async def foo_get(req):
 
 
 MANIFEST = {
+    'name': 'routing01',
     'router': router,
 }

--- a/tests/extensions/type-baddefined01/server.py
+++ b/tests/extensions/type-baddefined01/server.py
@@ -4,4 +4,4 @@ foo_schema = {
         'email': { 'type': 'string', 'format': 'email' },
     }
 }
-MANIFEST = {"types": {"foo": foo_schema}}
+MANIFEST = {"name": "type-baddefined01", "types": {"foo": foo_schema}}

--- a/tests/extensions/type-welldefined01/server.py
+++ b/tests/extensions/type-welldefined01/server.py
@@ -5,4 +5,4 @@ foo_schema = {
     },
     'relationships': {}
 }
-MANIFEST = {"types": {"foo": foo_schema}}
+MANIFEST = {"name": "type-welldefined01", "types": {"foo": foo_schema}}

--- a/tests/extensions/type/server.py
+++ b/tests/extensions/type/server.py
@@ -5,4 +5,4 @@ foo_schema = {
     },
     'relationships': {}
 }
-MANIFEST = {"types": {"foo": foo_schema}}
+MANIFEST = {"name": "type", "types": {"foo": foo_schema}}

--- a/tests/extensions/vue-menu-item01/server.py
+++ b/tests/extensions/vue-menu-item01/server.py
@@ -1,3 +1,4 @@
 MANIFEST={
+    'name': 'vue-menu-item01',
     'includes': ['build.js']
 }

--- a/tests/extensions/vue-routing01/server.py
+++ b/tests/extensions/vue-routing01/server.py
@@ -2,5 +2,6 @@ from tozti.utils import RouterDef
 from aiohttp import web
 
 MANIFEST = {
+    'name': 'vue-routing01',
     'includes': ['build.js'],
 }

--- a/tests/test_find_exts.py
+++ b/tests/test_find_exts.py
@@ -26,12 +26,12 @@ def empty_extensions_entry_leave(request):
 
 @pytest.mark.parametrize("extensions",
         [
-            [("foo", Ext_format.SERVER_FILE, {"includes": ["a", "b"]})],
-            [("foo", Ext_format.SERVER_FOLDER, {"includes": ["a", "b"]})],
+            [("foo", Ext_format.SERVER_FILE, {"name": "foo", "includes": ["a", "b"]})],
+            [("foo", Ext_format.SERVER_FOLDER, {"name": "foo", "includes": ["a", "b"]})],
             [("bar", Ext_format.BAD_FORMAT, {})],
             [("foo", Ext_format.SERVER_FILE, None)],
-            [("foo", Ext_format.SERVER_FILE, None), ("bar", Ext_format.SERVER_FILE, {})],
-            [("foo", Ext_format.SERVER_FILE, {}), ("bar", Ext_format.SERVER_FILE, {})],
+            [("foo", Ext_format.SERVER_FILE, None), ("bar", Ext_format.SERVER_FILE, {"name": "bar"})],
+            [("foo", Ext_format.SERVER_FILE, {"name": "foo"}), ("bar", Ext_format.SERVER_FILE, {"name": "bar"})],
         ]
         )
 def test_find_exts(empty_extensions_entry_leave, extensions):
@@ -62,7 +62,7 @@ def test_find_exts(empty_extensions_entry_leave, extensions):
 
     # get the outputed result and the expected result
     output = list(tozti.__main__.find_exts())
-    expected = [tozti.app.Extension(name, **manifest) \
+    expected = [tozti.app.Extension(**manifest) \
             for name, ext_format, manifest in extensions   \
             if not (manifest is None or ext_format == Ext_format.BAD_FORMAT)]
 

--- a/tozti/__main__.py
+++ b/tozti/__main__.py
@@ -77,9 +77,9 @@ def find_exts():
             # but I agree, it has to be done
 
             if 'name' not in mod.MANIFEST:
-                logger.error('Error while loading extension {}, MANIFEST'
-                             'does not contain the `name`'
-                             'property'.format(extname))
+                raise ValueError('Error while loading extension {}, MANIFEST'
+                                 'does not contain the `name`'
+                                 'property'.format(extname))
 
             yield tozti.app.Extension(**mod.MANIFEST)
         except AttributeError:


### PR DESCRIPTION
This PR adds a mandatory `name` property to every extension's MANIFEST, so that we do not rely on folder names to determine this name anymore.