### PR TITLE
Moved resourceMixin inside main tozti export

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -5,7 +5,7 @@ import promiseFinally from 'promise.prototype.finally'
 
 promiseFinally.shim()
 
-export * from './mixins'
+import { resourceMixin } from './mixins'
 import { addRoutes, getRoutes } from './routes'
 import store from './store'
 import api from './api'
@@ -54,6 +54,7 @@ export function polymorphic_component(name, fallback) {
 
 
 const tozti = window.tozti = {
+  resourceMixin,
   addRoutes,
   store,
   api,


### PR DESCRIPTION
Since webpack does not make module exports available to other external js files, we cannot rely on named vs default exports for tozti.
So I simply moved `resourceMixin` which was a named export, inside `tozti`, meaning the mixin can now be loaded from extensions.

In the long run, we should look at how to make our core bundle available to extension files.