### PR TITLE
Keyed relationships

### DIFF
--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -112,14 +112,14 @@ def relationship_update(id, rel, data, session=None):
                       json={'data': data}, session=session)
 
 
-def relationship_append(id, rel, *data, session=None):
+def relationship_append(id, rel, data, session=None):
     """Append items to a to-many relationship."""
 
     return check_call('POST', '/store/resources/%s/%s' % (id, rel),
                       json={'data': data}, session=session)
 
 
-def relationship_delete(id, rel, *data, session=None):
+def relationship_delete(id, rel, data, session=None):
     """Delete items from a to-many relationship."""
 
     return check_call('DELETE', '/store/resources/%s/%s' % (id, rel),

--- a/tozti/core_schemas.py
+++ b/tozti/core_schemas.py
@@ -40,7 +40,8 @@ folder_schema = {
     'body': {
         'name': { 'type': 'string' },
         'children': {
-            'arity': 'to-many'
+            'type': 'relationship',
+            'arity': 'keyed'
         },
 
         'parents': {


### PR DESCRIPTION
A new arity for relationship: `arity: keyed`. The `data` part of the relationship object is an object mapping strings to linkages. One can update it like append on to-many relationships: `POST {resource}/{rel}` with payload `{data: {new-key: some-linkage, other-key: other-linkage}}`. Delete works the same way (with `DELETE` method).