### PR TITLE
fixed bug when extension name wasn't the same as the folder name

### DIFF
--- a/tests/extensions/bad_name/server.py
+++ b/tests/extensions/bad_name/server.py
@@ -1,0 +1,4 @@
+MANIFEST = {
+    "name": "good_name",
+    "includes": ["build.js"]
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,6 +20,10 @@ def test_tozti_routing(tozti):
     assert(tozti_still_running(tozti))
 
 
+@pytest.mark.extensions("bad_name")
+def test_tozti_bad_name(tozti):
+    # check if tozti is running
+    assert(tozti_still_running(tozti))
 
 """
 # vue routing

--- a/tozti/__main__.py
+++ b/tozti/__main__.py
@@ -81,7 +81,7 @@ def find_exts():
                                  'does not contain the `name`'
                                  'property'.format(extname))
 
-            yield tozti.app.Extension(**mod.MANIFEST)
+            yield tozti.app.Extension(folder_name = extname, **mod.MANIFEST)
         except AttributeError:
             logger.exception('Error while loading extension {}, skipping: no '
                              'MANIFEST found'.format(extname))
@@ -170,7 +170,7 @@ def main():
                 if extension.static_dir is None :
                     extension.static_dir = 'dist'
                 extension.set_static_dir_absolute(
-                    os.path.join(tozti.TOZTI_BASE, 'extensions', extension.name))
+                    os.path.join(tozti.TOZTI_BASE, 'extensions', extension.folder_name))
             app.register(extension)
     except Exception as err:
         logger.critical('Error while loading extensions: {}'

--- a/tozti/app.py
+++ b/tozti/app.py
@@ -63,7 +63,7 @@ class Extension:
         on_shutdown (function): A function to be executed when the hook\
             on_shutdown is executed by aiohttp
     """
-    def __init__(self, name, router=None, includes=(), static_dir=None,
+    def __init__(self, name, folder_name=None, router=None, includes=(), static_dir=None,
                  dependencies=(), _god_mode=None, on_response_prepare=None,
                  on_startup=None, on_cleanup=None, on_shutdown=None, types={},
                  **kwargs):
@@ -73,6 +73,10 @@ class Extension:
         """
 
         self.name = name
+        if folder_name is None:
+            self.folder_name = name
+        else:
+            self.folder_name = folder_name
 
         self.router = router
         self.includes = includes if isinstance(includes, list) else list(includes) 


### PR DESCRIPTION
Fixed the following issue:
If the extension name and the folder name were different, tozti would not load the extension